### PR TITLE
Change method name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To print a summary of an [everypolitician-data](https://github.com/everypolitici
 
 ```ruby
 require 'pull_request_summarizer'
-puts PullRequestSummarizer::Summarizer.new(16984).summarize
+puts PullRequestSummarizer::Summarizer.new(16984).summary
 ```
 
 Where `16984` is the pull request number in [everypolitician-data](https://github.com/everypolitician/everypolitician-data) that you want the review for.

--- a/lib/pull_request_summarizer/summarizer.rb
+++ b/lib/pull_request_summarizer/summarizer.rb
@@ -11,7 +11,7 @@ module PullRequestSummarizer
       @pull_request_number = pull_request_number
     end
 
-    def summarize
+    def summary
       pull_request = github.pull_request(everypolitician_data_repo, pull_request_number)
       files = github.pull_request_files(everypolitician_data_repo, pull_request_number)
       popolo_before_after = FindPopoloFiles.from(files).map do |file|


### PR DESCRIPTION
Use a noun rather than a verb for a method that returns something.
