### PR TITLE
Add a rake task for running this gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ puts Everypolitician::PullRequest::Summary.new(16984).as_markdown
 
 Where `16984` is the pull request number in [everypolitician-data](https://github.com/everypolitician/everypolitician-data) that you want the review for.
 
+### Integration with rake
+
+To add the rake tasks put the following in your `Rakefile`:
+
+```ruby
+require 'everypolitician/pull_request/rake_task'
+Everypolitician::PullRequest::RakeTask.new
+```
+
+Then you can run the following tasks:
+
+    bundle exec rake pull_request_summary:print
+    bundle exec rake pull_request_summary:comment
+    bundle exec rake pull_request_summary:travis
+
+For a description of these tasks run:
+
+    bundle exec rake -T
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/everypolitician/pull_request/rake_task.rb
+++ b/lib/everypolitician/pull_request/rake_task.rb
@@ -1,0 +1,49 @@
+require 'rake'
+require 'rake/tasklib'
+
+module Everypolitician
+  module PullRequest
+    class RakeTask < ::Rake::TaskLib
+      attr_reader :name
+
+      def initialize(name = :pull_request_summary)
+        @name = name
+        setup_tasks
+      end
+
+      def setup_tasks
+        namespace(name) do
+          desc 'Print a summary of the given pull request'
+          task :print do
+            puts pull_request_summary(pull_request_number).as_markdown
+          end
+
+          desc 'Post a summary of the given pull request as a comment'
+          task :comment do
+            pull_request_summary(pull_request_number).post_to_github
+          end
+
+          desc 'Generate and post a pull request summary from Travis'
+          task :travis do
+            pull_request_summary(ENV['TRAVIS_PULL_REQUEST']).post_to_github_from_travis
+          end
+        end
+      end
+
+      private
+
+      def pull_request_summary(pull_request_number)
+        # Lazy load so we doesn't slow down the load time of the Rakefile.
+        require 'everypolitician/pull_request'
+        Everypolitician::PullRequest::Summary.new(pull_request_number)
+      end
+
+      def pull_request_number
+        ENV.fetch('PULL_REQUEST')
+      rescue KeyError
+        abort 'error: Please supply a pull request number in an environment' \
+          'variable, e.g. PULL_REQUEST=16984'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a rake task which encapsulates the logic for integrating this gem into another application's `Rakefile`. This means that you can now use this as follows:

``` ruby
require 'everypolitician/pull_request/rake_task'
Everypolitician::PullRequest::RakeTask.new
```
