### PR TITLE
More explicit rake task setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To add the rake tasks put the following in your `Rakefile`:
 
 ```ruby
 require 'everypolitician/pull_request/rake_task'
-Everypolitician::PullRequest::RakeTask.new
+Everypolitician::PullRequest::RakeTask.new.install_tasks
 ```
 
 Then you can run the following tasks:

--- a/lib/everypolitician/pull_request/rake_task.rb
+++ b/lib/everypolitician/pull_request/rake_task.rb
@@ -8,7 +8,6 @@ module Everypolitician
 
       def initialize(name = :pull_request_summary)
         @name = name
-        install_tasks
       end
 
       def install_tasks

--- a/lib/everypolitician/pull_request/rake_task.rb
+++ b/lib/everypolitician/pull_request/rake_task.rb
@@ -8,10 +8,10 @@ module Everypolitician
 
       def initialize(name = :pull_request_summary)
         @name = name
-        setup_tasks
+        install_tasks
       end
 
-      def setup_tasks
+      def install_tasks
         namespace(name) do
           desc 'Print a summary of the given pull request'
           task :print do


### PR DESCRIPTION
Rather than have lots of magic hidden behind `RakeTask#initialize` we instead want to force the user to explicitly call `RakeTask#install_tasks` so that it's clearer to future readers of the code what the task is _actually_ doing.
