### PR TITLE
Make the repo self-aware

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 require 'bundler/gem_tasks'
 require 'rake/testtask'
+require 'everypolitician/pull_request/rake_task'
+Everypolitician::PullRequest::RakeTask.new.install_tasks
 
 Rake::TestTask.new(:test) do |t|
   t.libs << 'test'


### PR DESCRIPTION
Install the Rake tasks into the local Rakefile so that when developing in this repo we can call them, to see what local changes would look like against a live PR.
