### PR TITLE
Report on changing Memberships

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
 
+abort 'Ruby should be >= 2.1.0' unless RUBY_VERSION.to_f >= 2.1
+
 # Specify your gem's dependencies in everypolitician-pull_request.gemspec
 gemspec

--- a/comment_template.md.erb
+++ b/comment_template.md.erb
@@ -78,6 +78,32 @@ No organizations added
 No organizations removed
 <% end %>
 
+## Memberships
+
+### Added
+<% if file.memberships_added.any? %>
+<% file.memberships_added.group_by(&:legislative_period_id).sort_by { |t, _| t }.each do |t, ms| %>
+#### <%= t %>
+<% ms.sort_by { |m| m.person.sort_name }.each do |m| %>
+- <%= m.person.name %> <% if m.start_date || m.end_date %>(<%= m.start_date %> - <%= m.end_date %>)<% end %>
+<% end %>
+<% end %>
+<% else %>
+No memberships added
+<% end %>
+
+### Removed
+<% if file.memberships_removed.any? %>
+<% file.memberships_removed.group_by(&:legislative_period_id).sort_by { |t, _| t }.each do |t, ms| %>
+#### <%= t %>
+<% ms.sort_by { |m| m.person.sort_name }.each do |m| %>
+- <%= m.person.name %> <% if m.start_date || m.end_date %>(<%= m.start_date %> - <%= m.end_date %>)<% end %>
+<% end %>
+<% end %>
+<% else %>
+No memberships removed
+<% end %>
+
 ## Terms
 
 ### Added

--- a/everypolitician-pull_request.gemspec
+++ b/everypolitician-pull_request.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.1.0'
+
   spec.add_runtime_dependency 'everypolitician-popolo'
   spec.add_runtime_dependency 'require_all'
   spec.add_runtime_dependency 'octokit'

--- a/lib/everypolitician/pull_request/compare_popolo.rb
+++ b/lib/everypolitician/pull_request/compare_popolo.rb
@@ -49,6 +49,14 @@ module Everypolitician
         Report::Organizations.new(before, after).removed
       end
 
+      def memberships_added
+        Report::Memberships.new(before, after).added
+      end
+
+      def memberships_removed
+        Report::Memberships.new(before, after).removed
+      end
+
       def terms_added
         Report::Terms.new(before, after).added
       end

--- a/lib/everypolitician/pull_request/report/memberships.rb
+++ b/lib/everypolitician/pull_request/report/memberships.rb
@@ -1,0 +1,25 @@
+module Everypolitician
+  module PullRequest
+    class Report
+      class Memberships < Base
+        def added
+          @ma ||= (after_h.keys - before_h.keys).map { |k| after_h[k] }
+        end
+
+        def removed
+          @mr ||= (before_h.keys - after_h.keys).map { |k| before_h[k] }
+        end
+
+        private
+
+        def before_h
+          @before_h ||= before.memberships.map { |m| [m.document, m] }.to_h
+        end
+
+        def after_h
+          @after_h ||= after.memberships.map { |m| [m.document, m] }.to_h
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a section to the report on Memberships that have been added or removed. It's not 100% obvious yet exactly what format will be most useful for these, so for now try grouping by Term, and displaying only the person's name and start/end date (if applicable). Once we've seen it in action for a while it'll hopefully become apparent whether this is sufficient/suitable.
