### PR TITLE
Only display Terms and Elections sections if there are changes

### DIFF
--- a/comment_template.md.erb
+++ b/comment_template.md.erb
@@ -104,26 +104,22 @@ No memberships added
 No memberships removed
 <% end %>
 
+<% if file.terms_added.any? || file.terms_removed.any? %>
 ## Terms
-
-### Added
+<% end %>
 
 <% if file.terms_added.any? %>
+### Added
 <% file.terms_added.each do |term| %>
 - `<%= term.id %>` - <%= term.name %>
 <% end %>
-<% else %>
-No terms added
 <% end %>
 
-### Removed
-
 <% if file.terms_removed.any? %>
+### Removed
 <% file.terms_removed.each do |term| %>
 - `<%= term.id %>` - <%= term.name %>
 <% end %>
-<% else %>
-No terms removed
 <% end %>
 
 <% if file.elections_added.any? || file.elections_removed.any? %>

--- a/comment_template.md.erb
+++ b/comment_template.md.erb
@@ -126,26 +126,22 @@ No terms added
 No terms removed
 <% end %>
 
+<% if file.elections_added.any? || file.elections_removed.any? %>
 ## Elections
-
-### Added
+<% end %>
 
 <% if file.elections_added.any? %>
+### Added
 <% file.elections_added.each do |election| %>
 - `<%= election.id %>` - <%= election.name %>
 <% end %>
-<% else %>
-No elections added
 <% end %>
 
-### Removed
-
 <% if file.elections_removed.any? %>
+### Removed
 <% file.elections_removed.each do |election| %>
 - `<%= election.id %>` - <%= election.name %>
 <% end %>
-<% else %>
-No elections removed
 <% end %>
 
 <% end %>


### PR DESCRIPTION
The output from this has grown quite long, and I suspect that the best
approach is to only show sections where there are relevant changes, so
that they stand out more, rather than having a wall of text even when
there's nothing that needs attention.

As an initial test, I'd like to try only showing the Terms and Elections
sections if something has changed within them, as these are the ones
that change least. After we live with that for a while it should be more
obvious whether to revert or do the same, or similar, or something else
entirely for People/Orgs/Memberships.

A good example case for this (where there's a new Term but no Election changes:

```
PULL_REQUEST=22451 bundle exec rake pull_request_summary:print
```