### PR TITLE
Make sure VCR dependency is at least 3.0.3

### DIFF
--- a/everypolitician-pull_request.gemspec
+++ b/everypolitician-pull_request.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.42'
-  spec.add_development_dependency 'vcr', '~> 3.0'
+  spec.add_development_dependency 'vcr', '~> 3.0.3'
   spec.add_development_dependency 'webmock', '~> 2.1'
 end


### PR DESCRIPTION
Versions of VCR before this version didn't support webmock 2, so we want to make sure that developers always install a compatible version of VCR.

Part of https://github.com/everypolitician/everypolitician/issues/583