### PR TITLE
Add ensure-regression-tests script to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ rvm:
   - 2.2.5
   - 2.3.1
 before_install: gem install bundler -v 1.12.5
+script:
+  - bundle exec rake
+  - bash <(curl -fsSL https://github.com/everypolitician/ensure-regression-tests/raw/master/ensure-regression-tests)


### PR DESCRIPTION
This adds the `ensure-regression-tests` script to the Travis build.

Part of https://github.com/everypolitician/everypolitician/issues/588