### PR TITLE
Ignore sources on memberships changing

### DIFF
--- a/everypolitician-pull_request.gemspec
+++ b/everypolitician-pull_request.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'everypolitician-popolo'
   spec.add_runtime_dependency 'require_all'
   spec.add_runtime_dependency 'octokit'
+  spec.add_runtime_dependency 'activesupport'
 
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/lib/everypolitician/pull_request/report/memberships.rb
+++ b/lib/everypolitician/pull_request/report/memberships.rb
@@ -13,11 +13,16 @@ module Everypolitician
         private
 
         def before_h
-          @before_h ||= before.memberships.map { |m| [m.document, m] }.to_h
+          @before_h ||= before.memberships.map { |m| [document_without_sources(m.document), m] }.to_h
         end
 
         def after_h
-          @after_h ||= after.memberships.map { |m| [m.document, m] }.to_h
+          @after_h ||= after.memberships.map { |m| [document_without_sources(m.document), m] }.to_h
+        end
+
+        def document_without_sources(doc)
+          doc.delete(:sources)
+          doc
         end
       end
     end

--- a/lib/everypolitician/pull_request/report/memberships.rb
+++ b/lib/everypolitician/pull_request/report/memberships.rb
@@ -15,15 +15,11 @@ module Everypolitician
         private
 
         def before_h
-          @before_h ||= before.memberships.map { |m| [filtered_document(m.document), m] }.to_h
+          @before_h ||= before.memberships.map { |m| [m.document.except(:sources), m] }.to_h
         end
 
         def after_h
-          @after_h ||= after.memberships.map { |m| [filtered_document(m.document), m] }.to_h
-        end
-
-        def filtered_document(doc, ignore: %i(sources))
-          doc.except(*ignore)
+          @after_h ||= after.memberships.map { |m| [m.document.except(:sources), m] }.to_h
         end
       end
     end

--- a/lib/everypolitician/pull_request/report/memberships.rb
+++ b/lib/everypolitician/pull_request/report/memberships.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/hash'
+
 module Everypolitician
   module PullRequest
     class Report
@@ -13,16 +15,15 @@ module Everypolitician
         private
 
         def before_h
-          @before_h ||= before.memberships.map { |m| [document_without_sources(m.document), m] }.to_h
+          @before_h ||= before.memberships.map { |m| [filtered_document(m.document), m] }.to_h
         end
 
         def after_h
-          @after_h ||= after.memberships.map { |m| [document_without_sources(m.document), m] }.to_h
+          @after_h ||= after.memberships.map { |m| [filtered_document(m.document), m] }.to_h
         end
 
-        def document_without_sources(doc)
-          doc.delete(:sources)
-          doc
+        def filtered_document(doc, ignore: %i(sources))
+          doc.except(*ignore)
         end
       end
     end

--- a/test/everypolitician/pull_request/compare_popolo_test.rb
+++ b/test/everypolitician/pull_request/compare_popolo_test.rb
@@ -44,4 +44,9 @@ describe Everypolitician::PullRequest::ComparePopolo do
   it 'returns the added elections' do
     assert_equal ['Q16960120'], subject.elections_added.map(&:id)
   end
+
+  it 'ignores memberships when only the source url changes' do
+    assert_equal [], subject.memberships_added
+    assert_equal [], subject.memberships_removed
+  end
 end

--- a/test/fixtures/after.json
+++ b/test/fixtures/after.json
@@ -48,5 +48,18 @@
       "name": "Abkhazian parliamentary election, 2002",
       "start_date": "2002-03-02"
     }
+  ],
+  "memberships": [
+    {
+      "person_id": "ef41232b-daa4-40fd-a39f-1ff900e3b1c2",
+      "organization_id": "4d814738-39d3-4a09-835d-32a2ed47c3c3",
+      "legislative_period_id": "term/52",
+      "role": "member",
+      "sources": [
+        {
+          "url": "http://example.com/members/123-person-name-here"
+        }
+      ]
+    }
   ]
 }

--- a/test/fixtures/before.json
+++ b/test/fixtures/before.json
@@ -48,5 +48,18 @@
       "name": "Abkhazian parliamentary election, 1996",
       "start_date": "1996-11-23"
     }
+  ],
+  "memberships": [
+    {
+      "person_id": "ef41232b-daa4-40fd-a39f-1ff900e3b1c2",
+      "organization_id": "4d814738-39d3-4a09-835d-32a2ed47c3c3",
+      "legislative_period_id": "term/52",
+      "role": "member",
+      "sources": [
+        {
+          "url": "http://example.com/members/123"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
If the only thing about a membership that's changing is the source then we want to simply ignore this rather than generating lots of noise reporting on it.

Initial step towards #12 

# Notes to merger

Once https://github.com/everypolitician/everypolitician-pull_request/pull/21 has been merged into `master` we should merge `master` into this pull request to check that it does indeed have regression tests.