### PR TITLE
Require ruby >= 2.4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 inherit_from: 
   - https://raw.githubusercontent.com/everypolitician/everypolitician-data/master/.rubocop_base.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.3
   - 2.4
   - 2.5
   - 2.6

--- a/everypolitician-pull_request.gemspec
+++ b/everypolitician-pull_request.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = '>= 2.4.0'
 
   spec.add_runtime_dependency 'activesupport'
   spec.add_runtime_dependency 'everypolitician-popolo'


### PR DESCRIPTION
We want to use the new Unicode-friendly casecmp? which only appeared in 2.4
(and the primary user of this is a rake task in everypolitician-data, which
is now on 2.4)