### PR TITLE
Remove needless RUBY_VERSION check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,5 @@
 
 source 'https://rubygems.org'
 
-abort 'Ruby should be >= 2.1.0' unless RUBY_VERSION.to_f >= 2.1
-
 # Specify your gem's dependencies in everypolitician-pull_request.gemspec
 gemspec


### PR DESCRIPTION
We already have a 'required_ruby_version' in the gemspec file, so there's no need to also check it in the Gemfile.